### PR TITLE
[Feature]ダメージ軽減スキル実装

### DIFF
--- a/Assets/WorkSpace/KazArt/Scenes/AddSkillAttack_SCENE.unity
+++ b/Assets/WorkSpace/KazArt/Scenes/AddSkillAttack_SCENE.unity
@@ -770,7 +770,8 @@ MonoBehaviour:
   Player: {fileID: 586972730}
   upgradeManager: {fileID: 0}
   model: {fileID: 1601370354}
-  text: {fileID: 1584727851}
+  levelText: {fileID: 0}
+  expText: {fileID: 0}
   laneMoveTime: 0.3
   lanes:
   - {fileID: 526368926}
@@ -1320,9 +1321,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::PlayerStatus
   player: {fileID: 586972730}
   upgradeManager: {fileID: 430123544}
+  heartView: {fileID: 0}
   level: 0
   requireExp: 0
   exp: 0
+  HPLIMIT: 10
   maxHp: 0
   hp: 0
   attack: 0
@@ -1338,6 +1341,8 @@ MonoBehaviour:
   firstRapidFireSpeed: 1
   sr: {fileID: 586972733}
   lookAtRight: 1
+  damageReduction: {fileID: 11400000, guid: 4c8165ff24f5f5b45b202f2a54151e3c, type: 2}
+  damageNegate: {fileID: 11400000, guid: a92e6d01137a03b40ae96f3848fce274, type: 2}
 --- !u!4 &1601370355
 Transform:
   m_ObjectHideFlags: 0
@@ -1725,7 +1730,7 @@ MonoBehaviour:
   model: {fileID: 1601370354}
   basicAttack: {fileID: 11400000, guid: 1a1c84814568f594a9a3c92efbcb74b3, type: 2}
   skills:
-  - {fileID: 11400000, guid: eabf58a4892996449b8b77f22f1e6f20, type: 2}
+  - {fileID: 11400000, guid: a92e6d01137a03b40ae96f3848fce274, type: 2}
   - {fileID: 11400000, guid: f4b2445a81598be47bb93c7802bf3e51, type: 2}
   - {fileID: 11400000, guid: f9b379850d15cfc4496c5766ee71aac2, type: 2}
 --- !u!4 &1957288228

--- a/Assets/WorkSpace/KazArt/ScriptableObject/DamageNegate.asset
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/DamageNegate.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c2ff713c491bb54d8c7d58fc9d47609, type: 3}
+  m_Name: DamageNegate
+  m_EditorClassIdentifier: Assembly-CSharp::DamageNegate
+  name: DamageNegate
+  level: 1
+  coolTime: 10
+  duration: 3
+  isActive: 0

--- a/Assets/WorkSpace/KazArt/ScriptableObject/DamageNegate.asset.meta
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/DamageNegate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a92e6d01137a03b40ae96f3848fce274
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorkSpace/KazArt/ScriptableObject/DamageReduction.asset
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/DamageReduction.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 078d93c8734bbe9428ef0349f462d0ae, type: 3}
+  m_Name: DamageReduction
+  m_EditorClassIdentifier: Assembly-CSharp::DamageReduction
+  name: DamageReduction
+  level: 1
+  coolTime: 10
+  duration: 3
+  isActive: 0

--- a/Assets/WorkSpace/KazArt/ScriptableObject/DamageReduction.asset.meta
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/DamageReduction.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c8165ff24f5f5b45b202f2a54151e3c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/DamageNegate.cs
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/DamageNegate.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "DamageNegate", menuName = "ScriptableObjects/Skill/DamageNegate")]
+public class DamageNegate : EquipmentBase
+{
+    [Header("ƒ_ƒ[ƒW–³Œø‰»ŽžŠÔ")]
+    [SerializeField] private int duration;
+    [SerializeField] private bool isActive;
+
+    public bool IsActive => isActive;
+
+    public override void Activate(PlayerModel model)
+    {
+        model.StartCoroutine(ActiveDamageNegate());
+    }
+
+    private IEnumerator ActiveDamageNegate()
+    {
+        isActive = true;
+        yield return new WaitForSeconds(duration);
+        isActive = false;
+    }
+}

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/DamageNegate.cs.meta
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/DamageNegate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c2ff713c491bb54d8c7d58fc9d47609

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/DamageReduction.cs
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/DamageReduction.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "DamageReduction", menuName = "ScriptableObjects/Skill/DamageReduction")]
+public class DamageReduction : EquipmentBase
+{
+    [Header("ƒ_ƒ[ƒWŒyŒ¸Œø‰ÊŽžŠÔ")]
+    [SerializeField] private int duration;
+    [SerializeField] private bool isActive;
+
+    public bool IsActive => isActive;
+
+    public override void Activate(PlayerModel model)
+    {
+        model.StartCoroutine(ActiveDamageReduce());
+    }
+
+    private IEnumerator ActiveDamageReduce()
+    {
+        isActive = true;
+        yield return new WaitForSeconds(duration);
+        isActive = false;
+    }
+}

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/DamageReduction.cs.meta
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/DamageReduction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 078d93c8734bbe9428ef0349f462d0ae

--- a/Assets/WorkSpace/momiji/Script/Player/PlayerModel.cs
+++ b/Assets/WorkSpace/momiji/Script/Player/PlayerModel.cs
@@ -31,6 +31,10 @@ public class PlayerModel : MonoBehaviour
     [Header("見た目")]
     [SerializeField] private SpriteRenderer sr; //キャラ画像のSpriteRenderer
     [SerializeField] private bool lookAtRight = true; //trueの時右向き
+
+    [Header("ダメージ軽減スキル・無効化設定")]
+    [SerializeField] private DamageReduction damageReduction;
+    [SerializeField] private DamageNegate damageNegate;
     
     [Tooltip("レベルごとに増加するレベルアップに必要な経験値量")] const int RequireExpPerLevel = 100;
     
@@ -66,7 +70,7 @@ public class PlayerModel : MonoBehaviour
     //被ダメージ
     public void Damage(int damage)
     {
-        hp -= damage;
+        hp -= CalcDamage(damage);
         heartView.HPView();
         if (hp <= 0)
         {
@@ -74,6 +78,26 @@ public class PlayerModel : MonoBehaviour
         }
     }
     
+    //ダメージ計算
+    public int CalcDamage(int damage)
+    {
+        if(damageReduction.IsActive)
+        {
+            damage = Mathf.Max(0, damage - 1);
+            Debug.Log(damage + "与えられた");
+        }
+
+        if(damageNegate.IsActive)
+        {
+            damage = 0;
+            Debug.Log(damage + "与えられた");
+        }
+
+        Debug.Log(damage + "与えられた");
+
+        return damage;
+    }
+
     //キャラの向きを変える
     public void TurnAround()
     {


### PR DESCRIPTION
ダメージ軽減スキル及びダメージ無効化スキルを実装した
・効果時間とスキルが発動中か判定する変数が用意されている
・コルーチンを使ってスキルの持続時間を調整することができるようにした

PlayerModelの変更
・まずインスペクターのダメージ軽減スキル・無効化スキル設定のところでSOを設定してください
・CalcDamageというダメージ軽減、無効化、それ以外のもので場合分けされている。これは計算結果のdamageを戻り値としている ・hp-=damageだったところをhp-=CalcDamage(damage)というようにし、CalcDamageで計算された結果を示している。