### PR TITLE
[Feature]敵の動きを止めるスキル追加

### DIFF
--- a/Assets/WorkSpace/KazArt/Scenes/AddSkillAttack_SCENE.unity
+++ b/Assets/WorkSpace/KazArt/Scenes/AddSkillAttack_SCENE.unity
@@ -723,6 +723,63 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!1001 &666913261
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_Name
+      value: EnemySlime
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9069288921748573208, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
 --- !u!1 &767569032
 GameObject:
   m_ObjectHideFlags: 0
@@ -762,13 +819,14 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 767569032}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9ea57cab991e746d3a3d05ccd43c1b40, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerController
   Player: {fileID: 586972730}
   upgradeManager: {fileID: 0}
+  sceneChanger: {fileID: 0}
   model: {fileID: 1601370354}
   levelText: {fileID: 0}
   expText: {fileID: 0}
@@ -779,6 +837,9 @@ MonoBehaviour:
   - {fileID: 923961836}
   - {fileID: 1947700990}
   - {fileID: 2088738412}
+  audioSource: {fileID: 0}
+  moveClip: {fileID: 0}
+  laneChangeClip: {fileID: 0}
 --- !u!1 &923961836
 GameObject:
   m_ObjectHideFlags: 0
@@ -1730,8 +1791,8 @@ MonoBehaviour:
   model: {fileID: 1601370354}
   basicAttack: {fileID: 11400000, guid: 1a1c84814568f594a9a3c92efbcb74b3, type: 2}
   skills:
-  - {fileID: 11400000, guid: a92e6d01137a03b40ae96f3848fce274, type: 2}
-  - {fileID: 11400000, guid: f4b2445a81598be47bb93c7802bf3e51, type: 2}
+  - {fileID: 11400000, guid: 01d61e8327138a941a531a0560f19524, type: 2}
+  - {fileID: 11400000, guid: 5ca5e70f62d641d49804908ac8422f79, type: 2}
   - {fileID: 11400000, guid: f9b379850d15cfc4496c5766ee71aac2, type: 2}
 --- !u!4 &1957288228
 Transform:
@@ -2169,3 +2230,4 @@ SceneRoots:
   - {fileID: 932689392}
   - {fileID: 494161462}
   - {fileID: 1700494313}
+  - {fileID: 666913261}

--- a/Assets/WorkSpace/KazArt/ScriptableObject/Stun.asset
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/Stun.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbdd214b49fa18b46b81cdde0b53589e, type: 3}
+  m_Name: Stun
+  m_EditorClassIdentifier: Assembly-CSharp::Stun
+  name: Stun
+  level: 1
+  coolTime: 10
+  duration: 3
+  boxWidth: 4
+  boxHeight: 1
+  offSet: 2

--- a/Assets/WorkSpace/KazArt/ScriptableObject/Stun.asset.meta
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/Stun.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 01d61e8327138a941a531a0560f19524
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorkSpace/KazArt/ScriptableObject/StunAll.asset
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/StunAll.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 10937f6bb9b17d84d90f600e50ddd696, type: 3}
+  m_Name: StunAll
+  m_EditorClassIdentifier: Assembly-CSharp::StunAll
+  name: StunAll
+  level: 1
+  coolTime: 10
+  duration: 3

--- a/Assets/WorkSpace/KazArt/ScriptableObject/StunAll.asset.meta
+++ b/Assets/WorkSpace/KazArt/ScriptableObject/StunAll.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ca5e70f62d641d49804908ac8422f79
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/Stun.cs
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/Stun.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Stun", menuName = "ScriptableObjects/Skill/Stun")]
+public class Stun : EquipmentBase
+{
+    [Header("スタン持続時間")]
+    [SerializeField] private float duration;
+
+    [Header("当たり判定サイズ")]
+    [SerializeField] private float boxWidth;
+    [SerializeField] private float boxHeight;
+    [SerializeField] private float offSet;
+
+
+    public override void Activate(PlayerModel model)
+    {
+        Debug.Log("発動");
+
+        Vector2 ownerPos = model.transform.position;
+        Vector2 hitPos = ownerPos + (Vector2)model.transform.right * offSet;
+        Vector2 hitSize = new Vector2(boxWidth, boxHeight);
+
+        Collider2D[] targetEnemy = Physics2D.OverlapBoxAll(hitPos, hitSize, 0);
+
+        StunSkill(targetEnemy);
+    }
+
+    private void StunSkill(Collider2D[] targetEnemy)
+    {
+        foreach(var hit in targetEnemy)
+        {
+            if(hit.gameObject.CompareTag("Enemy"))
+            {
+                hit.gameObject.GetComponent<EnemyCore>()?.Stun(duration);
+            }
+        }
+    }
+}

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/Stun.cs.meta
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/Stun.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbdd214b49fa18b46b81cdde0b53589e

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/StunAll.cs
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/StunAll.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "StunAll", menuName = "ScriptableObjects/Skill/StunAll")]
+public class StunAll : EquipmentBase
+{
+    [Header("ƒXƒ^ƒ“‘±ŠÔ")]
+    [SerializeField] private float duration;
+
+    public override void Activate(PlayerModel model)
+    {
+        Debug.Log("”­“®");
+        GameObject[] enemies = GameObject.FindGameObjectsWithTag("Enemy");
+
+        foreach (GameObject enemy in enemies)
+        {
+            if(enemy.GetComponent<Renderer>().isVisible)
+            {
+                enemy.GetComponent<EnemyCore>().Stun(duration);
+            }
+        }
+    }
+}

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/StunAll.cs.meta
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/StunAll.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10937f6bb9b17d84d90f600e50ddd696


### PR DESCRIPTION
・スタン(範囲限定)およびすべての敵に対してスタンを発動するスキルを実装した

スタン(範囲限定)
・インスペクター上でスタン持続期間と当たり判定のサイズを入力することができる
・EnemyCoreにあるStunという関数を呼び出すことで実行することができる

スタン(すべての敵)
・インスペクター上でスタン持続期間を入力することができる
・FindGameObjectWithTagでEnemyを登録することでEnemyを取得している
・RendererのisVisibleを用いて画面内の敵すべてに対してスタンを実行するようにしている