### PR TITLE
スキル使用時に音を鳴らす処理を追加

### DIFF
--- a/Assets/ScriptableObjects/BasicAttacks/StraightShoot 1.asset
+++ b/Assets/ScriptableObjects/BasicAttacks/StraightShoot 1.asset
@@ -15,4 +15,6 @@ MonoBehaviour:
   name: Slash
   level: 1
   coolTime: 0
+  sound: {fileID: 8300000, guid: c2bd93d49bf7844e8a86e2b0f2ee0d46, type: 3}
   bulletPrefab: {fileID: 4492134659843027878, guid: 3d5bb0e0287b24b29981947327293768, type: 3}
+  flyEndless: 0

--- a/Assets/ScriptableObjects/BasicAttacks/StraightShoot.asset
+++ b/Assets/ScriptableObjects/BasicAttacks/StraightShoot.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   name: "\u30B9\u30E9\u30A4\u30E0\u30DC\u30FC\u30EB"
   level: 1
   coolTime: 0
+  sound: {fileID: 8300000, guid: f94e90af38912430da3a2abbda2136de, type: 3}
   bulletPrefab: {fileID: 8325350445536012867, guid: 8233ec1601fc049b4ba1fd11afe0fe36, type: 3}
   flyEndless: 1

--- a/Assets/ScriptableObjects/BasicAttacks/ZangekiAttack.asset
+++ b/Assets/ScriptableObjects/BasicAttacks/ZangekiAttack.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   name: "\u3056\u3093\u3052\u304D"
   level: 0
   coolTime: 0
+  sound: {fileID: 8300000, guid: c2bd93d49bf7844e8a86e2b0f2ee0d46, type: 3}
   zangekiPrefab: {fileID: 4492134659843027878, guid: 3d5bb0e0287b24b29981947327293768, type: 3}
   offset: {x: 0.8, y: 0}
   radius: 0.7

--- a/Assets/ScriptableObjects/Skills/AllLaneAttack.asset
+++ b/Assets/ScriptableObjects/Skills/AllLaneAttack.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   name: AllLaneAttack
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: f94e90af38912430da3a2abbda2136de, type: 3}
   bulletPrefab: {fileID: 8325350445536012867, guid: 8233ec1601fc049b4ba1fd11afe0fe36, type: 3}
   offSet: 0.75

--- a/Assets/ScriptableObjects/Skills/DamageNegate.asset
+++ b/Assets/ScriptableObjects/Skills/DamageNegate.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   name: DamageNegate
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
   duration: 3
   isActive: 0
   effect: {fileID: 626978043811673729, guid: ef7bf890a5412de478ff36ddd72bf673, type: 3}

--- a/Assets/ScriptableObjects/Skills/DamageReduction.asset
+++ b/Assets/ScriptableObjects/Skills/DamageReduction.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   name: DamageReduction
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
   duration: 3
   isActive: 0
   effect: {fileID: 626978043811673729, guid: ef7bf890a5412de478ff36ddd72bf673, type: 3}

--- a/Assets/ScriptableObjects/Skills/EraseBullet.asset
+++ b/Assets/ScriptableObjects/Skills/EraseBullet.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   name: EraseBullet
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
   enemyBullet: {fileID: 7523403266130047925, guid: 9a573caf764467a45941063d5838a400, type: 3}
   throwSpeed: 5
   boxWidth: 4

--- a/Assets/ScriptableObjects/Skills/HPrecover.asset
+++ b/Assets/ScriptableObjects/Skills/HPrecover.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   name: Heal
   level: 1
   coolTime: 5
+  sound: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}
   healAmount: 1
   healClip: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}

--- a/Assets/ScriptableObjects/Skills/HPrecover2.asset
+++ b/Assets/ScriptableObjects/Skills/HPrecover2.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   name: HealUp
   level: 1
   coolTime: 5
+  sound: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}
   healAmount: 3
   healClip: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}

--- a/Assets/ScriptableObjects/Skills/HPrecover3.asset
+++ b/Assets/ScriptableObjects/Skills/HPrecover3.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   name: MoreHealUp
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}
   healAmount: 7
   healClip: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}

--- a/Assets/ScriptableObjects/Skills/MultipleShoot.asset
+++ b/Assets/ScriptableObjects/Skills/MultipleShoot.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   name: multipleShoot
   level: 1
   coolTime: 2
+  sound: {fileID: 8300000, guid: f94e90af38912430da3a2abbda2136de, type: 3}
   bulletPrefab: {fileID: 8325350445536012867, guid: 8233ec1601fc049b4ba1fd11afe0fe36, type: 3}
   offsets:
   - {x: 0, y: 2.3, z: 0}

--- a/Assets/ScriptableObjects/Skills/Poison.asset
+++ b/Assets/ScriptableObjects/Skills/Poison.asset
@@ -15,8 +15,9 @@ MonoBehaviour:
   name: Poison
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
   poisonDuration: 5
   poisonInterval: 1
-  offSet: 2
   boxWidth: 4
   boxHeight: 1
+  offSet: 2

--- a/Assets/ScriptableObjects/Skills/Slow.asset
+++ b/Assets/ScriptableObjects/Skills/Slow.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   name: Slow
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
   slowDuration: 5
   speedDown: 50
   boxWidth: 4

--- a/Assets/ScriptableObjects/Skills/StraightShoot2.asset
+++ b/Assets/ScriptableObjects/Skills/StraightShoot2.asset
@@ -15,4 +15,6 @@ MonoBehaviour:
   name: Magic
   level: 1
   coolTime: 0
+  sound: {fileID: 8300000, guid: f94e90af38912430da3a2abbda2136de, type: 3}
   bulletPrefab: {fileID: 1045140358746843033, guid: 4abe72556de141146a9f4bd067af6415, type: 3}
+  flyEndless: 0

--- a/Assets/ScriptableObjects/Skills/Stun.asset
+++ b/Assets/ScriptableObjects/Skills/Stun.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   name: Stun
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
   duration: 3
   boxWidth: 4
   boxHeight: 1

--- a/Assets/ScriptableObjects/Skills/StunAll.asset
+++ b/Assets/ScriptableObjects/Skills/StunAll.asset
@@ -15,4 +15,5 @@ MonoBehaviour:
   name: StunAll
   level: 1
   coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
   duration: 3

--- a/Assets/ScriptableObjects/Skills/SwingSword.asset
+++ b/Assets/ScriptableObjects/Skills/SwingSword.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   name: 
   level: 1
   coolTime: 5
+  sound: {fileID: 8300000, guid: c2bd93d49bf7844e8a86e2b0f2ee0d46, type: 3}
   radius: 1.5
   effect: {fileID: 271370633281393084, guid: 7e10d161c5d301346aca5e481713802d, type: 3}

--- a/Assets/ScriptableObjects/Skills/SwingSword2.asset
+++ b/Assets/ScriptableObjects/Skills/SwingSword2.asset
@@ -15,5 +15,6 @@ MonoBehaviour:
   name: SwingSword_Wide
   level: 1
   coolTime: 5
+  sound: {fileID: 8300000, guid: c2bd93d49bf7844e8a86e2b0f2ee0d46, type: 3}
   radius: 2.5
   effect: {fileID: 271370633281393084, guid: 7e10d161c5d301346aca5e481713802d, type: 3}

--- a/Assets/ScriptableObjects/Skills/ThrowEnemy.asset
+++ b/Assets/ScriptableObjects/Skills/ThrowEnemy.asset
@@ -15,8 +15,9 @@ MonoBehaviour:
   name: 
   level: 1
   coolTime: 5
+  sound: {fileID: 8300000, guid: f94e90af38912430da3a2abbda2136de, type: 3}
+  enemyBullet: {fileID: 7287775562442470276, guid: ed736939a46d0b04fb302383a9315b4e, type: 3}
+  throwSpeed: 5
   boxWidth: 1
   boxHeight: 1
   offSet: 0.5
-  enemyBullet: {fileID: 7287775562442470276, guid: ed736939a46d0b04fb302383a9315b4e, type: 3}
-  throwSpeed: 5

--- a/Assets/WorkSpace/KazArt/Scripts/Skill/HPrecover.cs
+++ b/Assets/WorkSpace/KazArt/Scripts/Skill/HPrecover.cs
@@ -7,13 +7,9 @@ public class HPrecover : EquipmentBase
 {
     [Header("�񕜗�")]
     [SerializeField] private int healAmount;
-    [SerializeField] private AudioClip healClip;
-    private AudioSource audioSource;
   
     public override void Activate(PlayerModel model)
     {
-        audioSource = model.GetComponent<AudioSource>();
-        audioSource.PlayOneShot(healClip);
         model.HpRecovery(healAmount);
     }
 }

--- a/Assets/WorkSpace/kora/Scripts/Enemy/EnemyContext.cs
+++ b/Assets/WorkSpace/kora/Scripts/Enemy/EnemyContext.cs
@@ -16,6 +16,7 @@ public class EnemyContext : MonoBehaviour
     {
         _controller = controller;
         _gameObject = gameObject;
+        EnemyCore.PopupScore += SetScore;
     }
 
     public void SetCoreObject(GameObject coreObject)
@@ -55,11 +56,19 @@ public class EnemyContext : MonoBehaviour
     
     public void Destroy()
     {
+        EnemyCore.PopupScore -= SetScore;
         _controller.Destroy();
     }
 
     public GameObject Instantiate(GameObject obj, Vector3 pos)
     {
         return _controller.Instantiate(obj, pos);
+    }
+
+    private void SetScore(GameObject enemy, int score)
+    {
+        GameObject obj = Instantiate(scorePrefab, enemy.transform.position, Quaternion.identity);
+        obj.GetComponent<ScorePopup>().SetScore(score);
+        EnemyCore.PopupScore -= SetScore;
     }
 }

--- a/Assets/WorkSpace/kora/Scripts/Enemy/EnemyCore.cs
+++ b/Assets/WorkSpace/kora/Scripts/Enemy/EnemyCore.cs
@@ -24,7 +24,7 @@ public class EnemyCore : MonoBehaviour, IEnemy
 {
     public static event Action<int> AddExpToPlayer;
     public static event Action<int> AddScoreToPlayer;
-
+    public static event Action<GameObject, int> PopupScore; 
     public event Action OnDead;
     public event Action OnAttack;
     public event Action OnMove;
@@ -158,5 +158,7 @@ public class EnemyCore : MonoBehaviour, IEnemy
         AddScoreToPlayer?.Invoke(_data.score);
         //プレイヤーに経験値を加算する
         AddExpToPlayer?.Invoke(_data.exp);
+        //頭上にスコアを表示する
+        PopupScore?.Invoke(gameObject, _data.score);
     }
 }

--- a/Assets/WorkSpace/momiji/Scene/DisplayScoreOnEnemy#113.unity
+++ b/Assets/WorkSpace/momiji/Scene/DisplayScoreOnEnemy#113.unity
@@ -5206,6 +5206,7 @@ MonoBehaviour:
   - {fileID: 8300000, guid: f5cb626e53e44409aa1786d366510d54, type: 3}
   gameOverBGMClip: {fileID: 8300000, guid: 135ea5506912b402a9aee7d0c605e3f7, type: 3}
   clearBGMClip: {fileID: 8300000, guid: 2627d37022e7e499291c3278d2610e91, type: 3}
+  bossAppearClip: {fileID: 0}
 --- !u!1 &872786393
 GameObject:
   m_ObjectHideFlags: 0
@@ -8746,13 +8747,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 72740ac9ec53acd49807d73b908dbfd2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SceneContext
-  bounceLanes: []
   lanes:
   - {fileID: 526368926}
   - {fileID: 2119750817}
   - {fileID: 923961836}
   - {fileID: 1947700990}
   - {fileID: 2088738412}
+  canvas: {fileID: 0}
+  gameManager: {fileID: 0}
+  audioManager: {fileID: 0}
 --- !u!1 &1351617582
 GameObject:
   m_ObjectHideFlags: 0
@@ -11469,17 +11472,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1893631082}
   m_CullTransparentMesh: 1
---- !u!114 &1914998245 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7956039482882256677, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-  m_PrefabInstance: {fileID: 7646408174187528022}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
 --- !u!1 &1926470753
 GameObject:
   m_ObjectHideFlags: 0
@@ -12433,24 +12425,6 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 0
   m_SpriteSortPoint: 0
---- !u!1 &2103077979 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-  m_PrefabInstance: {fileID: 7646408174187528022}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2103077980
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2103077979}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aaee918d37bd64b16a3cd2d16d4e2b58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::ScorePopup
-  _scoreText: {fileID: 1914998245}
 --- !u!1 &2119750817
 GameObject:
   m_ObjectHideFlags: 0
@@ -12950,118 +12924,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2140326838}
   m_CullTransparentMesh: 1
---- !u!1001 &7646408174187528022
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2146383973870368354, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_Name
-      value: ScoreText
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 200
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4298077019090428907, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_Name
-      value: EnemyScoreCanvas
-      objectReference: {fileID: 0}
-    - target: {fileID: 5987596498031354842, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7390331991811769668, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      propertyPath: m_Camera
-      value: 
-      objectReference: {fileID: 1051644136}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2103077980}
-  m_SourcePrefab: {fileID: 100100000, guid: d676faf3e96f54531bae616495ca2459, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -13076,4 +12938,3 @@ SceneRoots:
   - {fileID: 723456971}
   - {fileID: 1126396345}
   - {fileID: 1847676518}
-  - {fileID: 7646408174187528022}

--- a/Assets/WorkSpace/momiji/Script/Equipment/EquipmentBase.cs
+++ b/Assets/WorkSpace/momiji/Script/Equipment/EquipmentBase.cs
@@ -6,5 +6,7 @@ public abstract class EquipmentBase : ScriptableObject
     public int level; //強化レベル
     [Tooltip("ステータスの連射速度に加算するクールタイム")]
     public float coolTime;
+    [Tooltip("使用時にならす音")]
+    public AudioClip sound;
     public abstract void Activate(PlayerModel model);
 }

--- a/Assets/WorkSpace/momiji/Script/Manager/AudioManager.cs
+++ b/Assets/WorkSpace/momiji/Script/Manager/AudioManager.cs
@@ -80,4 +80,9 @@ public class AudioManager : MonoBehaviour
             bgmAudioSource.Play();
         }
     }
+
+    public void OneShot(AudioClip clip)
+    {
+        seAudioSource.PlayOneShot(clip);
+    }
 }

--- a/Assets/WorkSpace/momiji/Script/Player/PlayerAttackController.cs
+++ b/Assets/WorkSpace/momiji/Script/Player/PlayerAttackController.cs
@@ -61,6 +61,7 @@ public class PlayerAttackController : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.X) && timers[1] >= model.RapidFireSpeed + skills[0]?.coolTime)
         {
             skills[0]?.Activate(model);
+            audioManager.OneShot(skills[0].sound);
             timers[1] = 0f;
         }
 
@@ -68,6 +69,7 @@ public class PlayerAttackController : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.C) && timers[2] >= model.RapidFireSpeed + skills[1]?.coolTime)
         {
             skills[1]?.Activate(model);
+            audioManager.OneShot(skills[1].sound);
             timers[2] = 0f;
         }
 
@@ -75,20 +77,11 @@ public class PlayerAttackController : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.V) && timers[3] >= model.RapidFireSpeed + skills[2]?.coolTime)
         {
             skills[2]?.Activate(model);
+            audioManager.OneShot(skills[2].sound);
             timers[3] = 0f;
         }
 
         DisplayCoolTimeBar();
-    }
-
-    public bool HasSkill(string skillName)
-    {
-        foreach (var skill in skills)
-        {
-            if(skill.name == skillName) return true;
-        }
-        
-        return false;
     }
 
     //クールタイムをSliderに表示させる


### PR DESCRIPTION
EquipmentBaseにsoundという変数を追加。
PlayerAttackControlerからEquipmentBaseのsoundを使用することで、スキルごとに設定した音を鳴らすことができる。 

EnemyCoreとEnemyContextに、倒した敵の頭上にスコアを表示する処理を追加。
->スコアが表示されないときがあるので、要修正
close #113 