### PR TITLE
Enemy死亡後の当たり判定を無効化

### DIFF
--- a/Assets/Prefab/Enemy/EnemyPoisonSlime.prefab
+++ b/Assets/Prefab/Enemy/EnemyPoisonSlime.prefab
@@ -350,9 +350,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b81ceb7b14a7c94b8d6e92f647dd34f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShotSingle
-  damageCollider: {fileID: 8150685975065029820}
+  contactDamageCollider: {fileID: 8150685975065029820}
+  takeDamageCollider:
+  - {fileID: 7710772669456489449}
   shotPoint: {fileID: 8759148217643277841}
   sr: {fileID: 3332777169600125922}
+  rb: {fileID: 5939030543876509912}
   scorePrefab: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
 --- !u!114 &184661188946122840
 MonoBehaviour:

--- a/Assets/Prefab/Enemy/EnemySlime.prefab
+++ b/Assets/Prefab/Enemy/EnemySlime.prefab
@@ -291,9 +291,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b81ceb7b14a7c94b8d6e92f647dd34f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyCore
-  damageCollider: {fileID: 8082797589827680314}
+  contactDamageCollider: {fileID: 8082797589827680314}
+  takeDamageCollider:
+  - {fileID: 7520136305236063426}
   shotPoint: {fileID: 8759148217643277841}
   sr: {fileID: 3332777169600125922}
+  rb: {fileID: 5939030543876509912}
   scorePrefab: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
 --- !u!114 &8458903826754264497
 MonoBehaviour:

--- a/Assets/Prefab/Enemy/EnemySoldier.prefab
+++ b/Assets/Prefab/Enemy/EnemySoldier.prefab
@@ -350,9 +350,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b81ceb7b14a7c94b8d6e92f647dd34f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyShotSingle
-  damageCollider: {fileID: 1902663831437125397}
+  contactDamageCollider: {fileID: 1902663831437125397}
+  takeDamageCollider:
+  - {fileID: 6594710456288293898}
   shotPoint: {fileID: 3106744930323405570}
   sr: {fileID: 3332777169600125922}
+  rb: {fileID: 5939030543876509912}
   scorePrefab: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
 --- !u!114 &4178904381060203437
 MonoBehaviour:

--- a/Assets/Prefab/Enemy/EnemyWizard.prefab
+++ b/Assets/Prefab/Enemy/EnemyWizard.prefab
@@ -281,9 +281,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b81ceb7b14a7c94b8d6e92f647dd34f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyContext
-  damageCollider: {fileID: 2431734203080842033}
+  contactDamageCollider: {fileID: 2431734203080842033}
+  takeDamageCollider:
+  - {fileID: -4201303877913084997}
   shotPoint: {fileID: 1539722480947085157}
   sr: {fileID: 5411023765377325731}
+  rb: {fileID: -6972040618617840218}
   scorePrefab: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
 --- !u!114 &7303530488461795586
 MonoBehaviour:

--- a/Assets/Prefab/Enemy/MetalSlime.prefab
+++ b/Assets/Prefab/Enemy/MetalSlime.prefab
@@ -317,9 +317,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b81ceb7b14a7c94b8d6e92f647dd34f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyContext
-  damageCollider: {fileID: 8082797589827680314}
+  contactDamageCollider: {fileID: 8082797589827680314}
+  takeDamageCollider:
+  - {fileID: 7520136305236063426}
   shotPoint: {fileID: 8759148217643277841}
   sr: {fileID: 3332777169600125922}
+  rb: {fileID: 5939030543876509912}
   scorePrefab: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
 --- !u!114 &70583353845057733
 MonoBehaviour:

--- a/Assets/Prefab/Enemy/TestBoss.prefab
+++ b/Assets/Prefab/Enemy/TestBoss.prefab
@@ -953,9 +953,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b81ceb7b14a7c94b8d6e92f647dd34f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnemyContext
-  damageCollider: {fileID: 192511724214827100}
+  contactDamageCollider: {fileID: 192511724214827100}
+  takeDamageCollider:
+  - {fileID: 8372845332519816060}
+  - {fileID: 8770319744722269527}
   shotPoint: {fileID: 5388298929091285907}
   sr: {fileID: 8789029463910743384}
+  rb: {fileID: 6709984521583131392}
   scorePrefab: {fileID: 5593453957742890521, guid: d676faf3e96f54531bae616495ca2459, type: 3}
 --- !u!114 &6053799333216041222
 MonoBehaviour:

--- a/Assets/WorkSpace/kora/Scripts/Enemy/Behaviours/EnemyContactEffect.cs
+++ b/Assets/WorkSpace/kora/Scripts/Enemy/Behaviours/EnemyContactEffect.cs
@@ -25,7 +25,7 @@ public class EnemyContactEffect : EnemyBehaviourBase
         _isDamageable = param.isDamageable;
         _isDestroy = param.isDestroy;
         _damage = param.damage;
-        _damageCollider = Context.damageCollider;
+        _damageCollider = Context.contactDamageCollider;
     }
     
     public override void OnHitPlayer(Collider2D other)

--- a/Assets/WorkSpace/kora/Scripts/Enemy/EnemyContext.cs
+++ b/Assets/WorkSpace/kora/Scripts/Enemy/EnemyContext.cs
@@ -1,11 +1,14 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 public class EnemyContext : MonoBehaviour
 {
-    [Header("接触判定")][SerializeField] public Collider2D damageCollider;
+    [Header("接触ダメージ判定")][SerializeField] public Collider2D contactDamageCollider;
+    [Header("攻撃を受けるcollider")] [SerializeField] public List<Collider2D> takeDamageCollider;
     [Header("発射位置")][SerializeField] public GameObject shotPoint;
     [Header("ダメージ時に点滅するsprite")] public SpriteRenderer sr;
-    [SerializeField] private GameObject scorePrefab;
+    [Header("Rigidbody")] [SerializeField] public Rigidbody2D rb;
+    [Header("scoreを表示するcanvas")][SerializeField] private GameObject scorePrefab;
     public GameObject ScorePrefab => scorePrefab;
     
     private EnemyController _controller;
@@ -17,6 +20,8 @@ public class EnemyContext : MonoBehaviour
         _controller = controller;
         _gameObject = gameObject;
         EnemyCore.PopupScore += SetScore;
+        
+        if (rb == null) rb = GetComponent<Rigidbody2D>();
     }
 
     public void SetCoreObject(GameObject coreObject)

--- a/Assets/WorkSpace/kora/Scripts/Enemy/EnemyCore.cs
+++ b/Assets/WorkSpace/kora/Scripts/Enemy/EnemyCore.cs
@@ -164,6 +164,15 @@ public class EnemyCore : MonoBehaviour, IEnemy
     private void Die()
     {
         OnDead?.Invoke();
+
+        // 全てのtakeDamageColliderを無効化
+        foreach (var c in _controller.Context.takeDamageCollider)
+        {
+            c.enabled = false;
+        }
+        // 重力は0に変更
+        _controller.Context.rb.gravityScale = 0;
+        
         //Debug.Log("Die: " + OnDead);
         if (_isBoss)
         {

--- a/Assets/WorkSpace/kora/Scripts/Enemy/ScriptableObject/BossBehaviour/BossContactEffect.cs
+++ b/Assets/WorkSpace/kora/Scripts/Enemy/ScriptableObject/BossBehaviour/BossContactEffect.cs
@@ -11,7 +11,7 @@ public class BossContactEffect : BossBehaviourBaseSO
     
     protected override void OnInit()
     {
-        _damageCollider = Context.damageCollider;
+        _damageCollider = Context.contactDamageCollider;
     }
 
     public override void OnHitPlayer(Collider2D other)


### PR DESCRIPTION
EnemyCore内でDieが呼ばれたとき、以下の処理によって無効化
- takeDamageを受ける部分のcolliderを一括無効化
- rigitBody.gravityScaleを0にする