### PR TITLE
毒スキルのアップグレード追加、ステージ難易度表記の変更

### DIFF
--- a/Assets/Scenes/InGame/STAGE_ONE.unity
+++ b/Assets/Scenes/InGame/STAGE_ONE.unity
@@ -8844,12 +8844,12 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 67c6e9fcaceb09a40a6ec93d9aacd112, type: 2}
   - {fileID: 11400000, guid: 7893491c52f0ad94685ca03dc9be064d, type: 2}
   - {fileID: 11400000, guid: ac31f4d028a7a6a4ea22652b54e2949e, type: 2}
-  - {fileID: 11400000, guid: 62eaa128cba272f43869b93194d5c55b, type: 2}
   - {fileID: 11400000, guid: 98481de9fb47f524395ed78c13d2751c, type: 2}
   - {fileID: 11400000, guid: 5b9d9f336e4e19c429a4bc8d3eacf51d, type: 2}
   - {fileID: 11400000, guid: b1a9d324f736bcf49bcddbfad162d7a1, type: 2}
   - {fileID: 11400000, guid: 0a7775d40d8dfd84baba3de6d57243fb, type: 2}
   - {fileID: 11400000, guid: 05fc36198f24e564d89aea2518f3d58e, type: 2}
+  - {fileID: 11400000, guid: e7a7f3657bafb33449be1cb30c56a1db, type: 2}
   diplayUpgradesNum: 3
   upgradePanel: {fileID: 1330237610}
   panelRects:

--- a/Assets/Scenes/InGame/STAGE_SELECT_SCENE.unity
+++ b/Assets/Scenes/InGame/STAGE_SELECT_SCENE.unity
@@ -688,94 +688,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: StagePanel_3
       objectReference: {fileID: 0}
-    - target: {fileID: 2417911202418232413, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2417911202418232413, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2417911202418232413, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2417911202418232413, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3434347385847638587, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: stageData
-      value: 
-      objectReference: {fileID: 11400000, guid: 361cffecda94e8645ab5e55909fea98a, type: 2}
-    - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7034899280980322068, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: stageName
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 7077673457347943578, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7077673457347943578, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7077673457347943578, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7077673457347943578, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8235365374531417436, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8235365374531417436, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8235365374531417436, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8235365374531417436, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8998433630405889280, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8998433630405889280, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8998433630405889280, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8998433630405889280, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1143,6 +1055,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 212642648}
     m_Modifications:
+    - target: {fileID: 999480290827100684, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 235
+      objectReference: {fileID: 0}
+    - target: {fileID: 999480290827100684, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 1198905148254381707, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -1227,6 +1147,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: StagePanel_2
       objectReference: {fileID: 0}
+    - target: {fileID: 1831395031995306080, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSize
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 1831395031995306080, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 45
+      objectReference: {fileID: 0}
     - target: {fileID: 2417911202418232413, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1247,6 +1175,14 @@ PrefabInstance:
       propertyPath: stageData
       value: 
       objectReference: {fileID: 11400000, guid: d3a8178bcf3dd9f4b8c99b538ea5b476, type: 2}
+    - target: {fileID: 3850675213026546010, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSize
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 3850675213026546010, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 70
+      objectReference: {fileID: 0}
     - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1262,6 +1198,14 @@ PrefabInstance:
     - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634486995985057646, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634486995985057646, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -200
       objectReference: {fileID: 0}
     - target: {fileID: 7034899280980322068, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: stageName
@@ -1937,6 +1881,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 212642648}
     m_Modifications:
+    - target: {fileID: 999480290827100684, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 235
+      objectReference: {fileID: 0}
+    - target: {fileID: 999480290827100684, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 1198905148254381707, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -2021,6 +1973,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: StagePanel_1
       objectReference: {fileID: 0}
+    - target: {fileID: 1831395031995306080, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSize
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 1831395031995306080, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 45
+      objectReference: {fileID: 0}
     - target: {fileID: 2417911202418232413, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2037,6 +1997,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3434347385847638587, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: stageData
+      value: 
+      objectReference: {fileID: 11400000, guid: 7b1442bbc56a4854ab9448eaa9df90fd, type: 2}
+    - target: {fileID: 3850675213026546010, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSize
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 3850675213026546010, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 70
+      objectReference: {fileID: 0}
     - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2052,6 +2024,14 @@ PrefabInstance:
     - target: {fileID: 6016023978379348304, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634486995985057646, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6634486995985057646, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -200
       objectReference: {fileID: 0}
     - target: {fileID: 7034899280980322068, guid: ca90670a535bf7b47b4e6155d62ab009, type: 3}
       propertyPath: stageName

--- a/Assets/Scenes/InGame/STAGE_THREE.unity
+++ b/Assets/Scenes/InGame/STAGE_THREE.unity
@@ -8842,13 +8842,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 106d1dae777f442a091f1d043e28a436, type: 2}
   - {fileID: 11400000, guid: 7752bf40fa98909409161caf4e207cb5, type: 2}
   - {fileID: 11400000, guid: 67c6e9fcaceb09a40a6ec93d9aacd112, type: 2}
-  - {fileID: 11400000, guid: 7893491c52f0ad94685ca03dc9be064d, type: 2}
   - {fileID: 11400000, guid: ac31f4d028a7a6a4ea22652b54e2949e, type: 2}
   - {fileID: 11400000, guid: 62eaa128cba272f43869b93194d5c55b, type: 2}
   - {fileID: 11400000, guid: 98481de9fb47f524395ed78c13d2751c, type: 2}
   - {fileID: 11400000, guid: 5b9d9f336e4e19c429a4bc8d3eacf51d, type: 2}
-  - {fileID: 11400000, guid: b1a9d324f736bcf49bcddbfad162d7a1, type: 2}
-  - {fileID: 11400000, guid: 0a7775d40d8dfd84baba3de6d57243fb, type: 2}
   - {fileID: 11400000, guid: 05fc36198f24e564d89aea2518f3d58e, type: 2}
   diplayUpgradesNum: 3
   upgradePanel: {fileID: 1330237610}
@@ -9249,337 +9246,235 @@ MonoBehaviour:
   waves:
   - spawnTime: 1
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 423413088}
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
   - spawnTime: 5
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 571631438}
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1275203100}
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
   - spawnTime: 10
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 120388281}
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
-    - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
-      spawnPoint: {fileID: 1008840894}
-      spawnMoveTime: 2
-      targetPosition: {x: 2, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1743404263}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
   - spawnTime: 15
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 4430a4c09163f3c429aa1de343724d41, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 2
-      targetPosition: {x: -2, y: 0, z: 0}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
   - spawnTime: 20
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1306579116}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 571631438}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 423413088}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 120388281}
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 349227348}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1743404263}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1008840894}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1489431418}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1255025508}
       spawnMoveTime: 1
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
   - spawnTime: 25
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 4430a4c09163f3c429aa1de343724d41, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1255025508}
-      spawnMoveTime: 2
-      targetPosition: {x: 3, y: 0, z: 0}
+      spawnMoveTime: 1
+      targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-    - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
-      spawnPoint: {fileID: 423413088}
-      spawnMoveTime: 2
-      targetPosition: {x: -3, y: 0, z: 0}
-      isRight: 0
-  - spawnTime: 30
-    enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 349227348}
       spawnMoveTime: 1
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1743404263}
+  - spawnTime: 30
+    enamydatas:
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1275203100}
       spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 3a88225e77fda7f44960f56478e8d9b9, type: 3}
-      spawnPoint: {fileID: 1306579116}
-      spawnMoveTime: 2
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1275203100}
+      spawnMoveTime: 3
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+  - spawnTime: 35
+    enamydatas:
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 423413088}
+      spawnMoveTime: 1
       targetPosition: {x: -2, y: 0, z: 0}
       isRight: 0
   - spawnTime: 40
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 120388281}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 571631438}
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+  - spawnTime: 45
+    enamydatas:
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1255025508}
+      spawnMoveTime: 2
+      targetPosition: {x: 1, y: 0, z: 0}
+      isRight: 1
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1275203100}
+      spawnMoveTime: 3
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1008840894}
       spawnMoveTime: 1
       targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-  - spawnTime: 45
-    enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 4430a4c09163f3c429aa1de343724d41, type: 3}
-      spawnPoint: {fileID: 1255025508}
-      spawnMoveTime: 1
-      targetPosition: {x: 2, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
-      spawnPoint: {fileID: 349227348}
-      spawnMoveTime: 1
-      targetPosition: {x: 2, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1008840894}
-      spawnMoveTime: 1
-      targetPosition: {x: 2, y: 0, z: 0}
       isRight: 1
   - spawnTime: 50
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 2
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 3
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1743404263}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1008840894}
       spawnMoveTime: 1
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1743404263}
       spawnMoveTime: 2
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1743404263}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1489431418}
+      spawnMoveTime: 2
+      targetPosition: {x: 1, y: 0, z: 0}
+      isRight: 1
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 349227348}
       spawnMoveTime: 3
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 3a88225e77fda7f44960f56478e8d9b9, type: 3}
-      spawnPoint: {fileID: 120388281}
-      spawnMoveTime: 1
-      targetPosition: {x: -2, y: 0, z: 0}
-      isRight: 0
   - spawnTime: 55
     enamydatas:
-    - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
-      spawnPoint: {fileID: 423413088}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 120388281}
       spawnMoveTime: 1
-      targetPosition: {x: -2, y: 0, z: 0}
-      isRight: 0
-  - spawnTime: 60
-    enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 3a88225e77fda7f44960f56478e8d9b9, type: 3}
-      spawnPoint: {fileID: 571631438}
-      spawnMoveTime: 2
-      targetPosition: {x: -3, y: 0, z: 0}
-      isRight: 0
-  - spawnTime: 65
-    enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1255025508}
-      spawnMoveTime: 2
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 3
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
     - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1489431418}
+      spawnMoveTime: 1
+      targetPosition: {x: 1, y: 0, z: 0}
+      isRight: 1
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1306579116}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+  - spawnTime: 60
+    enamydatas:
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1306579116}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 571631438}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 423413088}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1275203100}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 120388281}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+  - spawnTime: 65
+    enamydatas:
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 349227348}
+      spawnMoveTime: 1
+      targetPosition: {x: 1, y: 0, z: 0}
+      isRight: 1
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1743404263}
+      spawnMoveTime: 1
+      targetPosition: {x: 1, y: 0, z: 0}
+      isRight: 1
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1008840894}
+      spawnMoveTime: 1
+      targetPosition: {x: 1, y: 0, z: 0}
+      isRight: 1
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1489431418}
+      spawnMoveTime: 1
+      targetPosition: {x: 1, y: 0, z: 0}
+      isRight: 1
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1255025508}
       spawnMoveTime: 1
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
   - spawnTime: 70
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 423413088}
+      spawnMoveTime: 1
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 571631438}
+      spawnMoveTime: 2
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
+      spawnPoint: {fileID: 1306579116}
+      spawnMoveTime: 3
+      targetPosition: {x: -1, y: 0, z: 0}
+      isRight: 0
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1008840894}
       spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
+      targetPosition: {x: -1, y: 0, z: 0}
       isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1743404263}
-      spawnMoveTime: 2
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1489431418}
       spawnMoveTime: 2
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 349227348}
-      spawnMoveTime: 3
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
+    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
       spawnPoint: {fileID: 1255025508}
       spawnMoveTime: 3
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
   - spawnTime: 75
     enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 3a88225e77fda7f44960f56478e8d9b9, type: 3}
-      spawnPoint: {fileID: 120388281}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 4430a4c09163f3c429aa1de343724d41, type: 3}
-      spawnPoint: {fileID: 1489431418}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
-      spawnPoint: {fileID: 1306579116}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-  - spawnTime: 80
-    enamydatas:
     - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
-      spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 1
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 2c664869627644f4b80912e799cf5c3e, type: 3}
-      spawnPoint: {fileID: 1743404263}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
       spawnPoint: {fileID: 423413088}
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 571631438}
-      spawnMoveTime: 2
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1275203100}
-      spawnMoveTime: 2
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1306579116}
-      spawnMoveTime: 3
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 120388281}
-      spawnMoveTime: 3
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 0
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1008840894}
-      spawnMoveTime: 1
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1743404263}
-      spawnMoveTime: 2
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1489431418}
-      spawnMoveTime: 2
-      targetPosition: {x: 1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1306579116}
-      spawnMoveTime: 3
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 1
-    - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
-      spawnPoint: {fileID: 1306579116}
-      spawnMoveTime: 3
-      targetPosition: {x: -1, y: 0, z: 0}
-      isRight: 1
-  - spawnTime: 100
-    enamydatas:
-    - enemyPrefab: {fileID: 8759148217643277841, guid: 8bcc8501ae7fb1f4f89766b15135d06c, type: 3}
-      spawnPoint: {fileID: 571631438}
-      spawnMoveTime: 5
-      targetPosition: {x: -4.5, y: 0, z: 0}
       isRight: 0
 --- !u!1 &1269887229
 GameObject:
@@ -14144,7 +14039,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 72fbb6ea18d8747c0ad05ac07adeedae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GameManager
-  clearTime: 100
+  clearTime: 90
   gameTimer: 0
   scoreManager: {fileID: 223086938}
   audioManager: {fileID: 848539689}

--- a/Assets/Scenes/InGame/STAGE_TWO.unity
+++ b/Assets/Scenes/InGame/STAGE_TWO.unity
@@ -8836,20 +8836,13 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c6b05e35b11864554ac1898fcfc7fd88, type: 2}
   - {fileID: 11400000, guid: 4404b5c660f864a8c90012efafec7db3, type: 2}
   - {fileID: 11400000, guid: e9bc66030dcd95c4fb4c2be847056436, type: 2}
-  - {fileID: 11400000, guid: 83b9608e4be0d4328a0d345f22cc0edb, type: 2}
   - {fileID: 11400000, guid: 3bdb94fe599674c94a1b408b1a8dafa4, type: 2}
   - {fileID: 11400000, guid: 01032360648d14f43b424035a34cfbb3, type: 2}
-  - {fileID: 11400000, guid: 106d1dae777f442a091f1d043e28a436, type: 2}
   - {fileID: 11400000, guid: 7752bf40fa98909409161caf4e207cb5, type: 2}
   - {fileID: 11400000, guid: 67c6e9fcaceb09a40a6ec93d9aacd112, type: 2}
-  - {fileID: 11400000, guid: 7893491c52f0ad94685ca03dc9be064d, type: 2}
-  - {fileID: 11400000, guid: ac31f4d028a7a6a4ea22652b54e2949e, type: 2}
-  - {fileID: 11400000, guid: 62eaa128cba272f43869b93194d5c55b, type: 2}
-  - {fileID: 11400000, guid: 98481de9fb47f524395ed78c13d2751c, type: 2}
-  - {fileID: 11400000, guid: 5b9d9f336e4e19c429a4bc8d3eacf51d, type: 2}
   - {fileID: 11400000, guid: b1a9d324f736bcf49bcddbfad162d7a1, type: 2}
-  - {fileID: 11400000, guid: 0a7775d40d8dfd84baba3de6d57243fb, type: 2}
   - {fileID: 11400000, guid: 05fc36198f24e564d89aea2518f3d58e, type: 2}
+  - {fileID: 11400000, guid: e7a7f3657bafb33449be1cb30c56a1db, type: 2}
   diplayUpgradesNum: 3
   upgradePanel: {fileID: 1330237610}
   panelRects:

--- a/Assets/ScriptableObjects/Skills/HPrecover3.asset
+++ b/Assets/ScriptableObjects/Skills/HPrecover3.asset
@@ -16,5 +16,4 @@ MonoBehaviour:
   level: 1
   coolTime: 10
   sound: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}
-  healAmount: 7
-  healClip: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}
+  healAmount: 5

--- a/Assets/ScriptableObjects/Skills/Poison2.asset
+++ b/Assets/ScriptableObjects/Skills/Poison2.asset
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0637bea7a624e2a40af79db33183a87a, type: 3}
+  m_Name: Poison2
+  m_EditorClassIdentifier: Assembly-CSharp::Poison
+  name: PoisonSizeUp
+  level: 1
+  coolTime: 10
+  sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}
+  prefab: {fileID: 5072948504032176861, guid: e2fb91d3e6b9019438bd4481cbd66450, type: 3}
+  distance: 3.05
+  height: 0.97
+  throwingDuration: 2
+  arcCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 3.3571427
+      outSlope: 3.3571427
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0.06666667
+    - serializedVersion: 3
+      time: 0.32140198
+      value: 0.99628156
+      inSlope: -0
+      outSlope: -0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.5916667
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1.0095351
+      value: -0.979839
+      inSlope: -2.9827905
+      outSlope: -2.9827905
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.110029764
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  widthCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  duration: 5
+  damage: 5
+  hitInterval: 1
+  scaleMultiplier: 2

--- a/Assets/ScriptableObjects/Skills/Poison2.asset.meta
+++ b/Assets/ScriptableObjects/Skills/Poison2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27518aae6dd92044c914b3edabd6701a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Upgrades/PoisonSkillGet.asset
+++ b/Assets/ScriptableObjects/Upgrades/PoisonSkillGet.asset
@@ -16,5 +16,6 @@ MonoBehaviour:
   infoSentence: "\u6BD2\u30D3\u30F3\u3092\u6295\u3052\u3066\n\u306F\u3093\u3044\u5185\u306E\u3066\u304D\u306B\n5\u79D2\u9593\u4E00\u5B9A\u30C0\u30E1\u30FC\u30B8\n\u3092\u3042\u305F\u3048\u308B"
   icon: {fileID: 21300000, guid: 042307001ef517746a9b81b11c7f34b6, type: 3}
   rarity: 5
-  upgradeSkills: []
+  upgradeSkills:
+  - {fileID: 11400000, guid: 27518aae6dd92044c914b3edabd6701a, type: 2}
   newSkill: {fileID: 11400000, guid: c6d622193fc400841830c834c7231ea4, type: 2}

--- a/Assets/ScriptableObjects/Upgrades/PoisonSkillUpgrade.asset
+++ b/Assets/ScriptableObjects/Upgrades/PoisonSkillUpgrade.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 43aa4827770dc43d48561eafeff22583, type: 3}
+  m_Name: PoisonSkillUpgrade
+  m_EditorClassIdentifier: Assembly-CSharp::SkillUpgrade
+  titleName: "\u30B9\u30AD\u30EB\u5F37\u5316"
+  infoSentence: "\u6BD2\u30D3\u30F3\u306E\n\u30B5\u30A4\u30BA\u304C\n\uFF12\u500D\u306B\u306A\u308B"
+  icon: {fileID: 21300000, guid: 042307001ef517746a9b81b11c7f34b6, type: 3}
+  rarity: 3
+  preSkill: {fileID: 11400000, guid: c6d622193fc400841830c834c7231ea4, type: 2}
+  newSkill: {fileID: 11400000, guid: 27518aae6dd92044c914b3edabd6701a, type: 2}

--- a/Assets/ScriptableObjects/Upgrades/PoisonSkillUpgrade.asset.meta
+++ b/Assets/ScriptableObjects/Upgrades/PoisonSkillUpgrade.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e7a7f3657bafb33449be1cb30c56a1db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorkSpace/momiji/Prefab/StagePanel_ranking.prefab
+++ b/Assets/WorkSpace/momiji/Prefab/StagePanel_ranking.prefab
@@ -167,7 +167,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1200557075400122576}
-  - {fileID: 1075335787923846518}
+  - {fileID: 6452348665061838638}
   - {fileID: 8057573514709482367}
   - {fileID: 6634486995985057646}
   - {fileID: 5699243153955068554}
@@ -190,13 +190,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d8b428cb619bf8540bb58119408eb907, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StagePanelSetting
-  stageData: {fileID: 11400000, guid: 7b1442bbc56a4854ab9448eaa9df90fd, type: 2}
-  difficultyStar:
-  - {fileID: 2545431188400172830}
-  - {fileID: 5737821911665302125}
-  - {fileID: 8403605530463671089}
-  - {fileID: 2790198263044797139}
-  - {fileID: 8226519631878579912}
+  stageData: {fileID: 11400000, guid: 361cffecda94e8645ab5e55909fea98a, type: 2}
   enemiySprite:
   - {fileID: 982649540281820648}
   - {fileID: 6787314398615580289}
@@ -205,6 +199,7 @@ MonoBehaviour:
   - {fileID: 388967275127013764}
   infoText: {fileID: 1831395031995306080}
   stageTitleText: {fileID: 3850675213026546010}
+  difficultyText: {fileID: 4142712499225834607}
 --- !u!1 &607238928961698105
 GameObject:
   m_ObjectHideFlags: 0
@@ -836,8 +831,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 60
-  m_fontSizeBase: 60
+  m_fontSize: 70
+  m_fontSizeBase: 70
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -881,81 +876,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &1415459388342314428
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8998433630405889280}
-  - component: {fileID: 4400534157713710043}
-  - component: {fileID: 2790198263044797139}
-  m_Layer: 5
-  m_Name: star_3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8998433630405889280
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1415459388342314428}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1075335787923846518}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4400534157713710043
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1415459388342314428}
-  m_CullTransparentMesh: 1
---- !u!114 &2790198263044797139
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1415459388342314428}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -1507387797, guid: 7bb12e1a1363c514bb9ee72a9acafce2, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1475333440890082060
 GameObject:
   m_ObjectHideFlags: 0
@@ -1046,7 +966,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3ec6bcbdd6e19f489e6013ac1c59519, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::StageSelect
-  stageName: 0
+  stageName: 9
 --- !u!1 &1592534017804073938
 GameObject:
   m_ObjectHideFlags: 0
@@ -1081,7 +1001,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -39, y: -196}
+  m_AnchoredPosition: {x: -60, y: -200}
   m_SizeDelta: {x: 1000, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5649791209581925471
@@ -1139,8 +1059,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40
-  m_fontSizeBase: 40
+  m_fontSize: 45
+  m_fontSizeBase: 45
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -1299,7 +1219,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 263, y: 19}
+  m_AnchoredPosition: {x: 235, y: 20}
   m_SizeDelta: {x: 1000, y: 800}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9157435884822187845
@@ -1603,81 +1523,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &2156226013865190536
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7077673457347943578}
-  - component: {fileID: 6619272693803306726}
-  - component: {fileID: 8403605530463671089}
-  m_Layer: 5
-  m_Name: star_2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7077673457347943578
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2156226013865190536}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1075335787923846518}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6619272693803306726
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2156226013865190536}
-  m_CullTransparentMesh: 1
---- !u!114 &8403605530463671089
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2156226013865190536}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -1507387797, guid: 7bb12e1a1363c514bb9ee72a9acafce2, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2489925631434591223
 GameObject:
   m_ObjectHideFlags: 0
@@ -1892,81 +1737,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &3649061061034112383
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8235365374531417436}
-  - component: {fileID: 8233857104146306131}
-  - component: {fileID: 8226519631878579912}
-  m_Layer: 5
-  m_Name: star_4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8235365374531417436
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3649061061034112383}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1075335787923846518}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &8233857104146306131
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3649061061034112383}
-  m_CullTransparentMesh: 1
---- !u!114 &8226519631878579912
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3649061061034112383}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -1507387797, guid: 7bb12e1a1363c514bb9ee72a9acafce2, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4413445295176281060
 GameObject:
   m_ObjectHideFlags: 0
@@ -2007,81 +1777,6 @@ RectTransform:
   m_AnchoredPosition: {x: -110, y: -50}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &4436101190192395631
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6016023978379348304}
-  - component: {fileID: 2535671915146357928}
-  - component: {fileID: 2545431188400172830}
-  m_Layer: 5
-  m_Name: star_0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6016023978379348304
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4436101190192395631}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1075335787923846518}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &2535671915146357928
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4436101190192395631}
-  m_CullTransparentMesh: 1
---- !u!114 &2545431188400172830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4436101190192395631}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -1507387797, guid: 7bb12e1a1363c514bb9ee72a9acafce2, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4447774257846320702
 GameObject:
   m_ObjectHideFlags: 0
@@ -2232,113 +1927,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &5154274151660154694
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1075335787923846518}
-  - component: {fileID: 6900085524240373720}
-  - component: {fileID: 921058872222292544}
-  - component: {fileID: 6862409098626332639}
-  m_Layer: 5
-  m_Name: DifficultyPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1075335787923846518
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5154274151660154694}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.4, y: 0.4, z: 0.4}
-  m_ConstrainProportionsScale: 1
-  m_Children:
-  - {fileID: 6016023978379348304}
-  - {fileID: 2417911202418232413}
-  - {fileID: 7077673457347943578}
-  - {fileID: 8998433630405889280}
-  - {fileID: 8235365374531417436}
-  m_Father: {fileID: 2125414152070380957}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -83, y: 41}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6900085524240373720
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5154274151660154694}
-  m_CullTransparentMesh: 1
---- !u!114 &921058872222292544
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5154274151660154694}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &6862409098626332639
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5154274151660154694}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 0
-  m_Spacing: 5
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!1 &6093653983892841593
 GameObject:
   m_ObjectHideFlags: 0
@@ -2452,81 +2040,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -148}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6916409514810322036
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2417911202418232413}
-  - component: {fileID: 3566343195171564906}
-  - component: {fileID: 5737821911665302125}
-  m_Layer: 5
-  m_Name: star_1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2417911202418232413
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6916409514810322036}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1075335787923846518}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3566343195171564906
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6916409514810322036}
-  m_CullTransparentMesh: 1
---- !u!114 &5737821911665302125
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6916409514810322036}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -1507387797, guid: 7bb12e1a1363c514bb9ee72a9acafce2, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6944753067840376400
 GameObject:
   m_ObjectHideFlags: 0
@@ -2602,6 +2115,143 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7331400805889441398
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6452348665061838638}
+  - component: {fileID: 6098585001294736531}
+  - component: {fileID: 4142712499225834607}
+  m_Layer: 5
+  m_Name: DifficultyText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6452348665061838638
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7331400805889441398}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2125414152070380957}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2, y: 39}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6098585001294736531
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7331400805889441398}
+  m_CullTransparentMesh: 1
+--- !u!114 &4142712499225834607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7331400805889441398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u304B\u3093\u305F\u3093"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: fa6f5369f4889447ea53d642e5a9b226, type: 2}
+  m_sharedMaterial: {fileID: 1537351824987109123, guid: fa6f5369f4889447ea53d642e5a9b226, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 25.536133, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &8744541740628357680
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/WorkSpace/momiji/Script/Manager/GameManager.cs
+++ b/Assets/WorkSpace/momiji/Script/Manager/GameManager.cs
@@ -30,7 +30,7 @@ public class GameManager : MonoBehaviour
             gameTimer += Time.deltaTime;
         }
 
-        if (GameManagement.CurrentScene == SceneName.STAGE_TWO && gameTimer >= clearTime)
+        if ((GameManagement.CurrentScene == SceneName.STAGE_TWO || GameManagement.CurrentScene == SceneName.STAGE_THREE) && gameTimer >= clearTime)
         {
             GameClear();
         }

--- a/Assets/WorkSpace/momiji/Script/StageData.cs
+++ b/Assets/WorkSpace/momiji/Script/StageData.cs
@@ -1,16 +1,23 @@
 using UnityEngine;
 
+public enum DifficultyData
+{
+    EASY,
+    NORMAL,
+    HARD
+};
+
 [CreateAssetMenu(fileName = "StageData", menuName = "ScriptableObjects/StageData")]
 public class StageData : ScriptableObject
 {
     [Header("ステージ情報")]
-    [SerializeField] private int difficulty;
+    [SerializeField] private DifficultyData difficulty;
     [SerializeField] private Sprite[] enemies;
     [SerializeField] private string infoText;
     [SerializeField] private string stageTitleText;
 
     //getter
-    public int Difficulty => difficulty;
+    public DifficultyData Difficulty => difficulty;
     public Sprite[] Enemies => enemies;
     public string InfoText => infoText;
     public string StageTitleText => stageTitleText;

--- a/Assets/WorkSpace/momiji/Script/StagePanelSetting.cs
+++ b/Assets/WorkSpace/momiji/Script/StagePanelSetting.cs
@@ -6,27 +6,38 @@ public class StagePanelSetting : MonoBehaviour
 {
     [SerializeField] private StageData stageData;
     [Header("Data表示UI")]
-    [SerializeField] private Image[] difficultyStar;
     [SerializeField] private Image[] enemiySprite;
     [SerializeField] private TextMeshProUGUI infoText;
     [SerializeField] private TextMeshProUGUI stageTitleText;
+    [SerializeField] private TextMeshProUGUI difficultyText;
     
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        int star = stageData.Difficulty;
-        for (int i = 0; i < difficultyStar.Length; i++)
-        {
-            difficultyStar[i].enabled = i < star;
-        }
         int enemyNum = stageData.Enemies.Length;
         for (int i = 0; i < enemiySprite.Length; i++)
         {
             if(i < enemyNum) enemiySprite[i].sprite = stageData.Enemies[i];
             enemiySprite[i].enabled = i < enemyNum;
         }
+        
         infoText.text = stageData.InfoText;
         stageTitleText.text = stageData.StageTitleText;
+        
+        switch (stageData.Difficulty)
+        {
+            case DifficultyData.EASY:
+                difficultyText.text = "かんたん";
+                break;
+            case DifficultyData.NORMAL:
+                difficultyText.text = "ふつう";
+                break;
+            case DifficultyData.HARD:
+                difficultyText.text = "むずかしい";
+                break;
+            default:
+                break;
+        }
     }
     
 }

--- a/Assets/WorkSpace/momiji/ScriptableObject/StageData/StageData_1.asset
+++ b/Assets/WorkSpace/momiji/ScriptableObject/StageData/StageData_1.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4149a332323ec44baab97d05d45ef30, type: 3}
   m_Name: StageData_1
   m_EditorClassIdentifier: Assembly-CSharp::StageData
-  difficulty: 5
+  difficulty: 1
   enemies:
   - {fileID: 21300000, guid: 1e5cad15aaacfca4fad8319423579076, type: 3}
   - {fileID: 21300000, guid: a2127430e4ba1a94dbb5087dad5c8532, type: 3}
@@ -21,4 +21,4 @@ MonoBehaviour:
   - {fileID: 21300000, guid: cdb9e629dc263cf4ba2a452a77e1a5b4, type: 3}
   - {fileID: 21300082, guid: 1eaee135ce037439d925cee5e41ce026, type: 3}
   infoText: "\u3059\u3079\u3066\u306E\u3066\u304D\u304C\u304A\u305D\u3044\u304B\u304B\u308B\uFF01"
-  stageTitleText: "\u307E\u304A\u3046\u3050\u3093\u3060\u3093"
+  stageTitleText: "\u3010\u307E\u304A\u3046\u3050\u3093\u3060\u3093\u3011"

--- a/Assets/WorkSpace/momiji/ScriptableObject/StageData/StageData_2.asset
+++ b/Assets/WorkSpace/momiji/ScriptableObject/StageData/StageData_2.asset
@@ -12,9 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4149a332323ec44baab97d05d45ef30, type: 3}
   m_Name: StageData_2
   m_EditorClassIdentifier: Assembly-CSharp::StageData
-  difficulty: 1
+  difficulty: 0
   enemies:
   - {fileID: 21300000, guid: 1e5cad15aaacfca4fad8319423579076, type: 3}
   - {fileID: 21300000, guid: a2127430e4ba1a94dbb5087dad5c8532, type: 3}
-  infoText: "\u30B2\u30FC\u30E0\u304C\u82E6\u624B\u306A\u4EBA\u5411\u3051"
-  stageTitleText: "\u306F\u3058\u3081\u3066\u306E\u307C\u3046\u3051\u3093"
+  infoText: "\u305F\u305F\u304B\u3044\u304C\u82E6\u624B\u306A\u4EBA\u5411\u3051"
+  stageTitleText: "\u3010\u306F\u3058\u3081\u3066\u306E\u307C\u3046\u3051\u3093\u3011"

--- a/Assets/WorkSpace/momiji/ScriptableObject/StageData/StageData_3.asset
+++ b/Assets/WorkSpace/momiji/ScriptableObject/StageData/StageData_3.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4149a332323ec44baab97d05d45ef30, type: 3}
   m_Name: StageData_3
   m_EditorClassIdentifier: Assembly-CSharp::StageData
-  difficulty: 3
+  difficulty: 2
   enemies:
   - {fileID: 21300000, guid: cdb9e629dc263cf4ba2a452a77e1a5b4, type: 3}
-  infoText: "\u30E1\u30BF\u30EB\u30B9\u30E9\u30A4\u30E0\u3057\u304B\u3044\u306A\u3044"
-  stageTitleText: "\u30E1\u30BF\u30EB\u307E\u307F\u308C"
+  infoText: "\u304B\u305F\u3044\u3001\u306F\u3084\u3044\u3001\u3044\u305F\u3044"
+  stageTitleText: "\u3010\u30E1\u30BF\u30EB\u307E\u307F\u308C\u3011"


### PR DESCRIPTION
毒スキルの毒ビンサイズを大きくするアップグレードを追加した。
メタルまみれステージのEnemyGeneratorを調整した。
ステージ難易度の表記を星の数から「むずかしい」「ふつう」「かんたん」に変更した。
Closes #193 