### PR TITLE
ClearBGMのバグ修正と、スキルnameの設定

### DIFF
--- a/Assets/Scenes/InGame/STAGE_TWO.unity
+++ b/Assets/Scenes/InGame/STAGE_TWO.unity
@@ -9339,7 +9339,7 @@ MonoBehaviour:
       spawnMoveTime: 2
       targetPosition: {x: -2, y: 0, z: 0}
       isRight: 0
-  - spawnTime: 40
+  - spawnTime: 35
     enamydatas:
     - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
       spawnPoint: {fileID: 120388281}
@@ -9351,7 +9351,7 @@ MonoBehaviour:
       spawnMoveTime: 1
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-  - spawnTime: 45
+  - spawnTime: 40
     enamydatas:
     - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
       spawnPoint: {fileID: 1255025508}
@@ -9368,7 +9368,7 @@ MonoBehaviour:
       spawnMoveTime: 1
       targetPosition: {x: 2, y: 0, z: 0}
       isRight: 1
-  - spawnTime: 50
+  - spawnTime: 45
     enamydatas:
     - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
       spawnPoint: {fileID: 1275203100}
@@ -9395,14 +9395,14 @@ MonoBehaviour:
       spawnMoveTime: 1
       targetPosition: {x: -2, y: 0, z: 0}
       isRight: 0
-  - spawnTime: 60
+  - spawnTime: 50
     enamydatas:
     - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
       spawnPoint: {fileID: 571631438}
       spawnMoveTime: 2
       targetPosition: {x: -3, y: 0, z: 0}
       isRight: 0
-  - spawnTime: 65
+  - spawnTime: 55
     enamydatas:
     - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
       spawnPoint: {fileID: 1255025508}
@@ -9419,7 +9419,7 @@ MonoBehaviour:
       spawnMoveTime: 1
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-  - spawnTime: 70
+  - spawnTime: 60
     enamydatas:
     - enemyPrefab: {fileID: 8759148217643277841, guid: a224bdc6b3e76fd4eb70867a0eafc8c3, type: 3}
       spawnPoint: {fileID: 1008840894}
@@ -9446,7 +9446,7 @@ MonoBehaviour:
       spawnMoveTime: 3
       targetPosition: {x: 1, y: 0, z: 0}
       isRight: 1
-  - spawnTime: 75
+  - spawnTime: 65
     enamydatas:
     - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
       spawnPoint: {fileID: 120388281}
@@ -9463,7 +9463,7 @@ MonoBehaviour:
       spawnMoveTime: 1
       targetPosition: {x: -1, y: 0, z: 0}
       isRight: 0
-  - spawnTime: 80
+  - spawnTime: 70
     enamydatas:
     - enemyPrefab: {fileID: 7785345535377445664, guid: 9e2eaf116f3ad754287c886efcce81b2, type: 3}
       spawnPoint: {fileID: 1275203100}
@@ -14078,7 +14078,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 72fbb6ea18d8747c0ad05ac07adeedae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GameManager
-  clearTime: 100
+  clearTime: 80
   gameTimer: 0
   scoreManager: {fileID: 223086938}
   audioManager: {fileID: 848539689}

--- a/Assets/ScriptableObjects/Skills/HPrecover.asset
+++ b/Assets/ScriptableObjects/Skills/HPrecover.asset
@@ -12,9 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1ed651171f883b541996001e90917b5e, type: 3}
   m_Name: HPrecover
   m_EditorClassIdentifier: Assembly-CSharp::HPrecover
-  name: Heal
+  name: HPrecover
   level: 1
   coolTime: 5
   sound: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}
   healAmount: 1
-  healClip: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}

--- a/Assets/ScriptableObjects/Skills/HPrecover2.asset
+++ b/Assets/ScriptableObjects/Skills/HPrecover2.asset
@@ -12,9 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1ed651171f883b541996001e90917b5e, type: 3}
   m_Name: HPrecover2
   m_EditorClassIdentifier: Assembly-CSharp::HPrecover
-  name: HealUp
+  name: HPrecover2
   level: 1
   coolTime: 5
   sound: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}
   healAmount: 3
-  healClip: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}

--- a/Assets/ScriptableObjects/Skills/HPrecover3.asset
+++ b/Assets/ScriptableObjects/Skills/HPrecover3.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1ed651171f883b541996001e90917b5e, type: 3}
   m_Name: HPrecover3
   m_EditorClassIdentifier: Assembly-CSharp::HPrecover
-  name: MoreHealUp
+  name: HPrecover3
   level: 1
   coolTime: 10
   sound: {fileID: 8300000, guid: 10b75b917536d49db89ed8baa8a902e2, type: 3}

--- a/Assets/ScriptableObjects/Skills/Poison2.asset
+++ b/Assets/ScriptableObjects/Skills/Poison2.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0637bea7a624e2a40af79db33183a87a, type: 3}
   m_Name: Poison2
   m_EditorClassIdentifier: Assembly-CSharp::Poison
-  name: PoisonSizeUp
+  name: Poison2
   level: 1
   coolTime: 10
   sound: {fileID: 8300000, guid: 3273bb9856c844f1b8c1e6a4d8a3075d, type: 3}

--- a/Assets/ScriptableObjects/Skills/SwingSword.asset
+++ b/Assets/ScriptableObjects/Skills/SwingSword.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b2d2816ec81cfc46962263d106018e2, type: 3}
   m_Name: SwingSword
   m_EditorClassIdentifier: Assembly-CSharp::SwingSword
-  name: 
+  name: SwingSword
   level: 1
   coolTime: 5
   sound: {fileID: 8300000, guid: c2bd93d49bf7844e8a86e2b0f2ee0d46, type: 3}

--- a/Assets/ScriptableObjects/Skills/SwingSword2.asset
+++ b/Assets/ScriptableObjects/Skills/SwingSword2.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b2d2816ec81cfc46962263d106018e2, type: 3}
   m_Name: SwingSword2
   m_EditorClassIdentifier: Assembly-CSharp::SwingSword
-  name: SwingSword_Wide
+  name: SwingSword2
   level: 1
   coolTime: 5
   sound: {fileID: 8300000, guid: c2bd93d49bf7844e8a86e2b0f2ee0d46, type: 3}

--- a/Assets/ScriptableObjects/Skills/ThrowEnemy.asset
+++ b/Assets/ScriptableObjects/Skills/ThrowEnemy.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e2a54869382ed2b40ab9e5bbf27c34d7, type: 3}
   m_Name: ThrowEnemy
   m_EditorClassIdentifier: Assembly-CSharp::ThrowEnemy
-  name: 
+  name: ThrowEnemy
   level: 1
   coolTime: 5
   sound: {fileID: 8300000, guid: f94e90af38912430da3a2abbda2136de, type: 3}

--- a/Assets/ScriptableObjects/Upgrades/SlowSkillUpgrade.asset
+++ b/Assets/ScriptableObjects/Upgrades/SlowSkillUpgrade.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: SlowSkillUpgrade
   m_EditorClassIdentifier: Assembly-CSharp::SkillUpgrade
   titleName: "\u30B9\u30AD\u30EB\u5F37\u5316"
-  infoSentence: "\u3066\u304D\u306E\u3046\u3054\u304D\u3092\n\u3068\u3081\u308B"
+  infoSentence: "\u76EE\u306E\u524D\u306E\u3066\u304D\u306E\n\u52D5\u304D\u3092\u6B62\u3081\u308B"
   icon: {fileID: 21300000, guid: c7027860289b440548e84b12e1964877, type: 3}
   rarity: 3
   preSkill: {fileID: 11400000, guid: eabf58a4892996449b8b77f22f1e6f20, type: 2}

--- a/Assets/ScriptableObjects/Upgrades/StunSkillUpgrade.asset
+++ b/Assets/ScriptableObjects/Upgrades/StunSkillUpgrade.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: StunSkillUpgrade
   m_EditorClassIdentifier: Assembly-CSharp::SkillUpgrade
   titleName: "\u30B9\u30AD\u30EB\u5F37\u5316"
-  infoSentence: "\u4E00\u5B9A\u6642\u9593\n\u5168\u3066\u306E\u3066\u304D\u306E\n\u3046\u3054\u304D\u3092\u6B62\u3081\u308B"
+  infoSentence: "\u3059\u3079\u3066\u306E\u3066\u304D\u306E\n\u52D5\u304D\u3092\u6B62\u3081\u308B"
   icon: {fileID: 21300000, guid: 3ff00dfa32ec5430a8397e0e50c40ff0, type: 3}
   rarity: 1
   preSkill: {fileID: 11400000, guid: 01d61e8327138a941a531a0560f19524, type: 2}

--- a/Assets/WorkSpace/momiji/Script/Manager/GameManager.cs
+++ b/Assets/WorkSpace/momiji/Script/Manager/GameManager.cs
@@ -32,7 +32,7 @@ public class GameManager : MonoBehaviour
 
         if ((GameManagement.CurrentScene == SceneName.STAGE_TWO || GameManagement.CurrentScene == SceneName.STAGE_THREE) && gameTimer >= clearTime)
         {
-            GameClear();
+            if (!isClear) GameClear();
         }
     }
 
@@ -76,6 +76,8 @@ public class GameManager : MonoBehaviour
 
     public void GameClear()
     {
+        if (isClear) return;
+        
         GameManagement.GameState = GAMESTATE.CLEAR;
         isClear = true;
 

--- a/Assets/WorkSpace/momiji/Script/Player/PlayerEquipmentManager.cs
+++ b/Assets/WorkSpace/momiji/Script/Player/PlayerEquipmentManager.cs
@@ -41,10 +41,11 @@ public class PlayerEquipmentManager : MonoBehaviour
     }
     
     //スキルをアップグレードする
-    public void UpgradeSkill(EquipmentBase preSkill, EquipmentBase newSkill)
+    public void UpgradeSkill(EquipmentBase preSkill, EquipmentBase newSkill, Sprite icon)
     {
         int idx = attackController.Skills.FindIndex(s => s.name == preSkill.name);
         if (idx < 0) return;
         attackController.Skills[idx] = newSkill;
+        srs[idx].sprite = icon;
     }
 }

--- a/Assets/WorkSpace/momiji/Script/Upgrade/SkillUpgrade.cs
+++ b/Assets/WorkSpace/momiji/Script/Upgrade/SkillUpgrade.cs
@@ -8,12 +8,16 @@ public class SkillUpgrade : UpgradeBase
 
     public override bool CanAppear(PlayerEquipmentManager equipmentManager)
     {
-        if(equipmentManager.GetSkill(preSkill) != null) return true;
+        if(equipmentManager.GetSkill(preSkill) != null)
+        {
+            //Debug.Log(newSkill.name + ": Player have " + preSkill.name);
+            return true;
+        }
         return false;
     }
 
     public override void Apply(PlayerEquipmentManager equipmentManager)
     {
-        equipmentManager.UpgradeSkill(preSkill, newSkill);
+        equipmentManager.UpgradeSkill(preSkill, newSkill, icon);
     }
 }


### PR DESCRIPTION
はじめてのぼうけんステージのクリアBGMが繰り返し流れてしまうバグ修正した。
また、スキルの名前が設定されていないものがあったので、設定した。